### PR TITLE
gnuplot: update to 5.4.9

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : gnuplot
-version    : 5.4.8
-release    : 20
+version    : 5.4.9
+release    : 21
 source     :
-    - https://download.sourceforge.net/project/gnuplot/gnuplot/5.4.8/gnuplot-5.4.8.tar.gz : 931279c7caad1aff7d46cb4766f1ff41c26d9be9daf0bcf0c79deeee3d91f5cf
+    - https://download.sourceforge.net/project/gnuplot/gnuplot/5.4.9/gnuplot-5.4.9.tar.gz : a328a021f53dc05459be6066020e9a71e8eab6255d3381e22696120d465c6a97
 license    : gnuplot
 component  : programming
 summary    : Gnuplot is a portable command-line driven graphing utility
@@ -14,7 +14,7 @@ builddeps  :
     - pkgconfig(x11)
     - wxwidgets-devel
 setup      : |
-    %configure --with-readline=gnu
+    %configure --with-readline=gnu --with-qt=no
 build      : |
     %make
 install    : |

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -2,8 +2,8 @@
     <Source>
         <Name>gnuplot</Name>
         <Packager>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Packager>
         <License>gnuplot</License>
         <PartOf>programming</PartOf>
@@ -61,12 +61,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="20">
-            <Date>2023-07-19</Date>
-            <Version>5.4.8</Version>
+        <Update release="21">
+            <Date>2023-09-06</Date>
+            <Version>5.4.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Joey Riches</Name>
-            <Email>josephriches@gmail.com</Email>
+            <Name>Nazar Stasiv</Name>
+            <Email>nazar@autistici.org</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
### Summary
- check plugin version at time of import
- prevent segfault if GNUPLOT_DRIVER_DIR is invalid
- fix only y autoscale yerrorbars to points in xrange
- fix possible memory corruption if clipping causes 0-size polygons
- fix initialization of key box toggle state
- fix post handle pixmaps

### Test Plan
plot data; zoom into chat

### Checklist
- [X] Package was built and tested against unstable
